### PR TITLE
`College` now infers city from title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Collegiate
 
-A directory of University and Colleges on planet earth.
+A directory of universities, colleges, and other institutions of higher learning.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Collegiate
 
-A description of this package.
+A directory of University and Colleges on planet earth.

--- a/Sources/CollegeGroup/College/College.swift
+++ b/Sources/CollegeGroup/College/College.swift
@@ -31,7 +31,13 @@ public struct College: ExpressibleByStringLiteral {
     private var properties: Properties
     
     public init(stringLiteral value: StringLiteralType) {
-        self.properties = Properties(title: value)
+        let (title, city) = Self.title(from: value)
+        self.properties = Properties(title: title)
+        
+        if let city = city {
+            self.properties.address.city = city
+            
+        }
         
     }
     
@@ -57,6 +63,30 @@ public typealias CollegeGroupBuilder = MixedGroupBuilder<College>
 public extension College.Properties {
     var primaryAbbreviation: String? {
         abbreviations.first ?? title.initials
+    }
+    
+}
+
+
+// MARK: -
+
+fileprivate extension College {
+    static let citySeparators = [", ", " at ", " in "]
+    
+    static func title(from stringValue: String) -> (title: String, city: String?) {
+        guard let citySeparator = citySeparators.first(where: stringValue.contains) else {
+            return (stringValue, nil)
+        }
+        
+        let components = stringValue.split(separator: citySeparator)
+        
+        switch components.count {
+        case 2:
+            return (stringValue, components[1])
+            
+        default:
+            return (stringValue, nil)
+        }
     }
     
 }

--- a/Sources/Collegiate/UnitedStates.swift
+++ b/Sources/Collegiate/UnitedStates.swift
@@ -30,11 +30,9 @@ public struct UnitedStates: CollegeGroup {
                     .url(authority: "ua.edu")
                 
                 "University of Alabama at Birmingham"
-                    .city("Birmingham")
                     .url(authority: "uab.edu")
                 
                 "University of Alabama in Huntsville"
-                    .city("Huntsville")
                     .url(authority: "uah.edu")
                 
             }
@@ -70,16 +68,34 @@ public struct UnitedStates: CollegeGroup {
         Group {
             Group {
                 "University of California, Berkeley"
-                    .abbreviation("Cal", "UC Berkeley")
-                    .city("Berkeley")
+                    .abbreviation("UC Berkeley", "Cal")
                     .url(authority: "berkeley.edu")
+                
+                "University of California, Davis"
+                    .abbreviation("UC Davis", "UCD")
+                    .url(authority: "ucdavis.edu")
+                
+                "University of California, Irvine"
+                    .abbreviation("UCI", "UC Irvine")
+                    .url(authority: "uci.edu")
                 
                 "University of California, Los Angeles"
                     .city("Los Angeles", neighborhood: "Westwood")
                     .url(authority: "ucla.edu")
                 
+                "University of California, Merced"
+                    .abbreviation("UC Merced")
+                    .url(authority: "ucmerced.edu")
+                
+                "University of California, Riverside"
+                    .abbreviation("UCR", "UC Riverside")
+                    .url(authority: "ucr.edu")
+                
+                "University of California, San Diego"
+                    .abbreviation("UC San Diego", "UCSD")
+                    .url(authority: "ucsd.edu")
+                
                 "University of California, San Francisco"
-                    .city("San Francisco")
                     .url(authority: "ucsf.edu")
                 
             }
@@ -697,17 +713,14 @@ public struct UnitedStates: CollegeGroup {
             Group {
                 "University of Texas at Austin"
                     .abbreviation("UT Austin", "UT", "Texas")
-                    .city("Austin")
                     .url(authority: "utexas.edu")
                 
                 "University of Texas at Arlington"
                     .url(authority: "uta.edu")
                 
                 "University of Texas at El Paso"
-                    .city("El Paso")
                     .url(authority: "utep.edu")
                 
-                ""
             }
             
         }

--- a/Sources/Collegiate/UnitedStates.swift
+++ b/Sources/Collegiate/UnitedStates.swift
@@ -888,6 +888,11 @@ public struct UnitedStates: CollegeGroup {
                     .city("Morgantown")
                     .url(authority: "wvu.edu")
                 
+                "West Virginia University Institute of Technology"
+                    .abbreviation("WVU Tech", "WVIT", "WVU Beckley", "West Virginia Tech")
+                    .city("Beckley")
+                    .url("https://www.wvu.edu/wvutech/")
+                
                 "WVU Potomac State College"
                     .url(authority: "potomacstatecollege.edu")
                 
@@ -897,11 +902,6 @@ public struct UnitedStates: CollegeGroup {
             "West Virginia University at Parkersburg"
                 .city("Parkersburg")
                 .url(authority: "wvup.edu")
-            
-            "West Virginia University Institute of Technology"
-                .abbreviation("WVU Tech", "WVIT", "WVU Beckley", "West Virginia Tech")
-                .city("Beckley")
-                .url("https://www.wvu.edu/wvutech/")
             
             "West Virginia Wesleyan College"
                 .city("Buckhannon")

--- a/Sources/Collegiate/UnitedStates.swift
+++ b/Sources/Collegiate/UnitedStates.swift
@@ -16,6 +16,7 @@ public struct UnitedStates: CollegeGroup {
         case universityOfNorthCarolina
         case universityOfIllinois
         case universityOfTennessee
+        case universityOfTexas
         case universityOfSouthCarolina
         
     }
@@ -31,6 +32,10 @@ public struct UnitedStates: CollegeGroup {
                 "University of Alabama at Birmingham"
                     .city("Birmingham")
                     .url(authority: "uab.edu")
+                
+                "University of Alabama in Huntsville"
+                    .city("Huntsville")
+                    .url(authority: "uah.edu")
                 
             }
             .system(System.universityOfAlabama)
@@ -636,18 +641,26 @@ public struct UnitedStates: CollegeGroup {
                 .url(authority: "tusculum.edu")
             
             Group {
-                "University of Tennessee, Chattanooga"
+                "University of Tennessee at Chattanooga"
                     .city("Chattanooga")
                     .url(authority: "utc.edu")
+                
+                "University of Tennessee Health Science Center"
+                    .city("Memphis")
+                    .url(authority: "uthsc.edu")
                 
                 "University of Tennessee, Knoxville"
                     .abbreviation("UTK", "Tenn")
                     .city("Knoxville")
                     .url(authority: "utk.edu")
                 
-                "University of Tennessee, Martin"
+                "University of Tennessee at Martin"
                     .city("Martin")
                     .url(authority: "utm.edu")
+                
+                "University of Tennessee Space Institute"
+                    .city("Tullahoma")
+                    .url(authority: "utsi.edu")
                 
             }
             .system(System.universityOfTennessee)
@@ -681,14 +694,21 @@ public struct UnitedStates: CollegeGroup {
                 .city("Tyler")
                 .url(authority: "tjc.edu")
             
-            "University of Texas at Austin"
-                .abbreviation("UT Austin", "UT", "Texas")
-                .city("Austin")
-                .url(authority: "utexas.edu")
-            
-            "University of Texas at El Paso"
-                .city("El Paso")
-                .url(authority: "utep.edu")
+            Group {
+                "University of Texas at Austin"
+                    .abbreviation("UT Austin", "UT", "Texas")
+                    .city("Austin")
+                    .url(authority: "utexas.edu")
+                
+                "University of Texas at Arlington"
+                    .url(authority: "uta.edu")
+                
+                "University of Texas at El Paso"
+                    .city("El Paso")
+                    .url(authority: "utep.edu")
+                
+                ""
+            }
             
         }
         .state(.texas)
@@ -911,6 +931,9 @@ public extension UnitedStates.System {
         case .universityOfTennessee:
             "University of Tennessee"
             
+        case .universityOfTexas:
+            "University of Texas"
+            
         }
     }
     
@@ -933,6 +956,9 @@ public extension UnitedStates.System {
             
         case .universityOfTennessee:
             (42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42)
+            
+        case .universityOfTexas:
+            (233, 11, 227, 198, 95, 156, 76, 173, 136, 93, 88, 213, 146, 25, 16, 220)
             
         }
     }

--- a/Sources/Collegiate/UnitedStates.swift
+++ b/Sources/Collegiate/UnitedStates.swift
@@ -18,6 +18,7 @@ public struct UnitedStates: CollegeGroup {
         case universityOfTennessee
         case universityOfTexas
         case universityOfSouthCarolina
+        case westVirginiaUniversity
         
     }
     
@@ -856,8 +857,6 @@ public struct UnitedStates: CollegeGroup {
             
             "Pierpont Community and Technical College"
             
-            "Potomac State College of West Virginia University"
-            
             "Salem University"
                 .city("Salem")
                 .url(authority: "salemu.edu")
@@ -876,6 +875,7 @@ public struct UnitedStates: CollegeGroup {
             
             "West Virginia Northern Community College"
                 .city("Wheeling")
+                .url(authority: "wvncc.edu")
             
             "West Virginia School of Osteopathic Medicine"
             
@@ -883,9 +883,16 @@ public struct UnitedStates: CollegeGroup {
                 .city("Institute")
                 .url(authority: "wvstateu.edu")
             
-            "West Virginia University"
-                .city("Morgantown")
-                .url(authority: "wvu.edu")
+            Group {
+                "West Virginia University"
+                    .city("Morgantown")
+                    .url(authority: "wvu.edu")
+                
+                "WVU Potomac State College"
+                    .url(authority: "potomacstatecollege.edu")
+                
+            }
+            .system(System.westVirginiaUniversity)
             
             "West Virginia University at Parkersburg"
                 .city("Parkersburg")
@@ -947,6 +954,9 @@ public extension UnitedStates.System {
         case .universityOfTexas:
             "University of Texas"
             
+        case .westVirginiaUniversity:
+            "West Virginia University"
+            
         }
     }
     
@@ -972,6 +982,9 @@ public extension UnitedStates.System {
             
         case .universityOfTexas:
             (233, 11, 227, 198, 95, 156, 76, 173, 136, 93, 88, 213, 146, 25, 16, 220)
+            
+        case .westVirginiaUniversity:
+            (31, 85, 152, 235, 251, 236, 77, 131, 189, 235, 180, 60, 238, 142, 119, 198)
             
         }
     }


### PR DESCRIPTION
`College` objects now infer city for universities with names such as "University of Tennessee at Chattanooga", "University of California, Berkeley", or "University of Alabama in Huntsville."